### PR TITLE
Making the members link to the members tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
                     <p class="stats">
                         <a href="https://github.com/h5bp/repositories"><b id="num-repos">View</b> public repos</a>
                         <br>
-                        <a href="https://github.com/h5bp"><b id="num-members">View</b> members</a>
+                        <a href="https://github.com/h5bp?tab=members"><b id="num-members">View</b> members</a>
                     </p>
                     <h3>Recently updated</h3>
                     <ol id="updated-repos"></ol>


### PR DESCRIPTION
The members link currently just takes you to https://github.com/h5bp. This feels a bit weird. Not sure if this is on purpose or by mistake but I would guess it should take you to the members listing page.
