### PR TITLE
SVG logo to match PNG version

### DIFF
--- a/downloads/h5bp-logo.svg
+++ b/downloads/h5bp-logo.svg
@@ -1,31 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-     width="400px" height="400px" viewBox="0 0 400 400" enable-background="new 0 0 400 400" xml:space="preserve">
-
-    <!-- Background -->
-    <g id="background">
-        <rect fill="#222222" x="0" y="0" width="400" height="400"/>
-    </g>
-
-    <!-- 3d look -->
-    <g id="_3d-1">
-        <polygon fill="#304A51" points="100,322 135,339 217,282 187,260"/>
-    </g>
-    <g id="_3d-2">
-        <polygon fill="#466770" points="278,236 311,343 276,325 243,219"/>
-    </g>
-    <g id="_3d-3">
-        <polygon fill="#466770" points="223,156 251.125,156.125 221,72 186,55"/>
-    </g>
-    <g id="_3d-4">
-        <polygon fill="#304A51" points="243,219 328,156 363,174 278,236"/>
-    </g>
-
-    <!-- Star -->
-    <g id="star">
-        <polygon fill="#e08524" enable-background="new" points="187,260 100,322 131,219 45,156 151,156 186,55 223,156 328,156 243,219 276,325"/>
-        <path fill="#222222" d="M186,55l37,101h105l-85,63l33,106l-89-65l-87,62l31-103l-86-63h106L186,55 M186,37l-6,16l-34,97H45H26
-            l15,11l83,60l-30,99l-5,17l14-10l83-59l86,62l15,11l-5-17l-32-102l82-60l15-11h-18H227l-36-98L186,37L186,37z"/>
-    </g>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="500px" height="500px" viewBox="0 0 500 500" enable-background="new 0 0 500 500" xml:space="preserve">
+	<g id="background">
+		<rect fill="#222222" x="0" y="0" width="500" height="500"/>
+	</g>
+	<g transform="translate(0,-552.36218)">
+		<path d="M223.45,68.9,179.35,194.96,45.572,195.33,153.99,275.45,115.03,404.81,224.55,327.27,337.02,409.59,295.85,275.08,403.17,194.96,269.76,195.33,223.45,68.9" transform="translate(0,552.36218)" fill="#e08524"/>
+		<path d="m228.96,67.062,44.47,20.949,37.119,101.44-36.752,0-44.837-122.38" transform="translate(0,552.36218)" fill="#466770"/>
+		<path d="m305.35,277.81,43.919,21.57,106.29-77.183-43.919-23.389-106.29,79.002" transform="translate(0,552.36218)" fill="#304a51"/>
+		<path d="m305.29,277.73,43.979,21.554,41.58,134.45-45.478-23.129-40.081-132.87" transform="translate(0,552.36218)" fill="#466770"/>
+		<path d="m121.28,409.41,103.27-73.871,36.201,26.829-97.576,68.359-41.897-21.316" transform="translate(0,552.36218)" fill="#304a51"/>
+	</g>
 </svg>
+


### PR DESCRIPTION
A new SVG logo to match the provided PNG version. Fix the difference
between shadow lengths.

Second attempt.

Issue https://github.com/h5bp/h5bp.github.com/issues/3
