### PR TITLE
Ignore `h5bp-bot` when listing collaborators

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -36,7 +36,9 @@
         $.getJSON('https://api.github.com/repos/' + orgName + '/' + repo.name + '/collaborators?callback=?', function (result) {
             var collaborators = result.data;
             $.each(collaborators, function (i, collaborator) {
-                 $facepile.append($('<img src="' + collaborator.avatar_url + '" title="' + collaborator.login + '" alt="' + collaborator.login + '">'));
+                if(collaborator.login !== 'h5bp-bot') {
+                    $facepile.append($('<img src="' + collaborator.avatar_url + '" title="' + collaborator.login + '" alt="' + collaborator.login + '">'));
+                }
             });
         });
 


### PR DESCRIPTION
Since the `h5bp-bot` is a fully automated account, not a real "collaborator", I think it should be ignored when listing the collaborators of a repo.
