### PR TITLE
Solve https error with Twitter widgets

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -139,5 +139,5 @@
         };
 
     // Twitter SDK
-    add('http://platform.twitter.com/widgets.js', 'twitter-wjs');
+    add('//platform.twitter.com/widgets.js', 'twitter-wjs');
 }(document, 'script'));


### PR DESCRIPTION
When loading up the website using `https`, the twitter widgets break. This is 'cause the browser don't wants to load a needed javascript file (called `widgets.js`):

![screenshot 2014-09-16 19 12 53](https://cloud.githubusercontent.com/assets/6025224/4291654/5b432052-3dc6-11e4-9bde-3662bb20fdb6.png)

This can be simply fixed by loading that script over `https` (using a protocol-relative url).
