### PR TITLE
Add a canonical URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
         <link rel="stylesheet" href="assets/normalize.css">
         <link rel="stylesheet" href="assets/main.css">
         <link rel="stylesheet" href="assets/style.css">
+        <link rel="canonical" href="https://h5bp.org">
     </head>
     <body>
         <div class="grid">


### PR DESCRIPTION
> All pages should specify a valid canonical URL to get more control over how duplicate URLs are treated by search engines. When a set of URLs on your site return duplicate or near duplicate content, search engines will select a single definitive URL for that content called the canonical URL. This URL will be crawled more often, will take priority in search results over URLs with duplicate content and search rank boosting backlinks to the URLs with duplicate content will be viewed as linking to the canonical URL. Note that “self-canonicalizing” a page by setting its canonical URL to itself is both valid and useful as it can help eliminate potential duplicates such as when pages may be linked to with tracking URL parameters. To suggest the canonical URL for a page you can add a `<link rel="canonical" href="...">` tag inside the page’s <head> tag