### PR TITLE
update url of site to https://h5bp.org/ when using twitter share

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
                       <a class="twitter-share-button"
                       href="https://twitter.com/share"
                       data-text="All the H5BP projects in one place"
-                      data-url="https://h5bp.github.io/"
+                      data-url="https://h5bp.org"
                       data-via="h5bp"
                       data-count="none"
                       target="_blank">Tweet</a>


### PR DESCRIPTION
Use https://h5bp.org instead of https://h5bp.github.io/