### PR TITLE
bump supported node version to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "engines": {
-    "node": ">=6",
+    "node": ">=8",
     "npm": ">=3"
   },
   "babel": {


### PR DESCRIPTION
minor thing, but node v6 is not supported.
REF: https://nodejs.org/en/about/releases/