### PR TITLE
In medium screen, adjust to 640px so it can contain two columns

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -202,7 +202,7 @@ ol {
 
 @media (max-width: 960px) {
   body {
-    max-width: 620px;
+    max-width: 640px;
   }
 }
 


### PR DESCRIPTION
## Before

Before fixing, it can only contain one column in a medium screen, the rest of blank space are too large.

![image](https://github.com/user-attachments/assets/ea23ccee-56a8-4edc-a483-f1e00bed2b13)

## After

After fixing, it can contain two columns (centered) in a medium screen

![image](https://github.com/user-attachments/assets/26d659e2-acfb-44bc-b644-2c0e0a6f37ca)

## Why

https://github.com/h5bp/h5bp.github.io/blob/main/assets/style.css#L100-L102

The grid unit is 300px, with left and right margin 10px each. So if we want to wrap two colums, `max-width` should be calculated as `300px * 2 + 4 * 10px = 640px`. I think the original value `620px` is a typo.

What do you think?